### PR TITLE
Handling none in steamstore api returns

### DIFF
--- a/gameinsights/collector.py
+++ b/gameinsights/collector.py
@@ -320,8 +320,8 @@ class Collector:
         self, steam_appid: str, verbose: bool = True, review_only: bool = True
     ) -> pd.DataFrame:
 
-        if not steam_appid or not isinstance(steam_appid, str):
-            raise ValueError("steam_appid must be a non-empty string.")
+        if not steam_appid:
+            raise ValueError("steam_appid must be a non-empty.")
 
         reviews_data = self.steamreview.fetch(
             steam_appid=steam_appid,

--- a/gameinsights/sources/steamstore.py
+++ b/gameinsights/sources/steamstore.py
@@ -143,43 +143,50 @@ class SteamStore(BaseSource):
 
     def _transform_data(self, data: dict[str, Any]) -> dict[str, Any]:
         # repack / process the data if needed
-        price_overview = data.get("price_overview", {})
-        release_date = data.get("release_date", {})
-        platforms = data.get("platforms", {})
-        genres = data.get("genres", [])
-        categories = data.get("categories", [])
-        ratings = data.get("ratings", {})
+        price_overview = data.get("price_overview") or {}
+        release_date = data.get("release_date") or {}
+        platforms = data.get("platforms") or {}
+        genres = data.get("genres") or []
+        categories = data.get("categories") or []
+        ratings = data.get("ratings") or {}
 
         return {  # Default to None
-            "steam_appid": data.get("steam_appid", None),
-            "name": data.get("name", None),
-            "type": data.get("type", None),
-            "is_coming_soon": release_date.get("coming_soon", None),
-            "release_date": release_date.get("date", None),
-            "is_free": data.get("is_free", None),
-            "price_currency": price_overview.get("currency", None),
+            "steam_appid": data.get("steam_appid"),
+            "name": data.get("name"),
+            "type": data.get("type"),
+            "is_coming_soon": release_date.get("coming_soon"),
+            "release_date": release_date.get("date"),
+            "is_free": data.get("is_free"),
+            "price_currency": price_overview.get("currency"),
             "price_initial": (
-                price_overview.get("initial") / 100
-                if price_overview.get("initial", None) is not None
+                price_overview.get("initial") / 100  # type: ignore[operator]
+                if isinstance(price_overview, dict) and price_overview.get("initial") is not None
                 else None
             ),
             "price_final": (
-                price_overview.get("final") / 100
-                if price_overview.get("final", None) is not None
+                price_overview.get("final") / 100  # type: ignore[operator]
+                if isinstance(price_overview, dict) and price_overview.get("final") is not None
                 else None
             ),
-            "developers": data.get("developers", None),
-            "publishers": data.get("publishers", None),
+            "developers": data.get("developers"),
+            "publishers": data.get("publishers"),
             "platforms": [
-                platform for platform, is_supported in platforms.items() if is_supported
+                platform
+                for platform, is_supported in platforms.items()
+                if isinstance(platforms, dict) and is_supported
             ],
             "categories": [category["description"] for category in categories],
             "genres": [genre["description"] for genre in genres],
-            "metacritic_score": data.get("metacritic", {}).get("score", None),
-            "recommendations": data.get("recommendations", {}).get("total", None),
-            "achievements": data.get("achievements", {}).get("total", None),
-            "content_rating": [
-                {"rating_type": rating_type, "rating": rating["rating"]}
-                for rating_type, rating in ratings.items()
-            ],
+            "metacritic_score": data.get("metacritic", {}).get("score"),
+            "recommendations": data.get("recommendations", {}).get("total"),
+            "achievements": data.get("achievements", {}).get("total"),
+            "content_rating": (
+                [
+                    {"rating_type": rating_type, "rating": rating["rating"]}
+                    for rating_type, rating in ratings.items()
+                    if isinstance(ratings, dict) and isinstance(rating, dict)
+                ]
+                if ratings
+                else []
+            ),
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -417,6 +417,22 @@ def steamstore_success_response_data():
 
 
 @pytest.fixture
+def steamstore_success_partial_unexpected_data():
+    return {
+        "12345": {
+            "success": True,
+            "data": {
+                "type": "mock",
+                "name": "Mock Game: The Adventure",
+                "steam_appid": 12345,
+                "price_overview": [],  # unexpected data type
+                "ratings": None,  # this as well
+            },
+        }
+    }
+
+
+@pytest.fixture
 def steamstore_not_found_response_data():
     return {"12345": {"success": False}}
 

--- a/tests/sources/test_steamstore.py
+++ b/tests/sources/test_steamstore.py
@@ -38,6 +38,26 @@ class TestSteamStore:
         assert result["data"]["content_rating"][0]["rating_type"] == "pegi"
         assert result["data"]["content_rating"][0]["rating"] == "12"
 
+    def test_fetch_success_unexpected_data(
+        self,
+        mock_request_response,
+        steamstore_success_partial_unexpected_data,
+    ):
+        result = self._setup_fetch(
+            mock_request_response=mock_request_response,
+            response_data=steamstore_success_partial_unexpected_data,
+        )
+
+        assert result["success"] is True
+        assert result["data"]["steam_appid"] == 12345
+        assert result["data"]["type"] == "mock"
+        assert len(result["data"]) == len(steamstore._STEAM_LABELS)
+
+        # check if it successfully defaulted the unexpected data to None
+        assert result["data"]["price_currency"] is None
+        assert result["data"]["price_initial"] is None
+        assert result["data"]["content_rating"] == []
+
     @pytest.mark.parametrize(
         "selected_labels, expected_labels",
         [


### PR DESCRIPTION
### ✨ Summary

a quick fix for the unexpected value returns from steamstore api, this is just a quick fix.
I think the better fix is creating a proper data model for each sources with proper validation for each expected and default values.
But not for now, will do it later.
---

### 📦 Changes

- added mechanism to handle unexpected values from the api
- added test case for unexpected value case
- remove non-string check for `collector`'s `get_game_review`

### 🔗 Related Issues

WIP #4 